### PR TITLE
Fix: Service Token returns Forbidden instead of Unauthorized

### DIFF
--- a/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZAuthenticationFilter.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZAuthenticationFilter.java
@@ -43,9 +43,9 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
 
         val authentication = serviceTokenAuthentication.get();
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        logger.info("Service token authentication successful - Valid Service Token and Service ID");
+        logger.debug("Service token authentication successful - Valid Service Token and Service ID");
       } else {
-        logger.info("Service token authentication failed - Invalid Service Token or Service ID");
+        logger.debug("Service token authentication failed - Invalid Service Token or Service ID");
         resolveUnauthorized(response);
         return;
       }
@@ -56,7 +56,7 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
       // request.
 
       if (!authorizationHeader.startsWith("Bearer ")) {
-        logger.info("User token authentication failed - No Bearer token");
+        logger.debug("User token authentication failed - No Bearer token");
         resolveUnauthorized(response);
         return;
       }
@@ -64,10 +64,10 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
       String bearerToken = authorizationHeader.substring(7);
       val userTokenAuthentication = getUserTokenAuthentication(bearerToken);
       if (userTokenAuthentication.isPresent()) {
-        logger.info("User token authentication successful - Valid User Token");
+        logger.debug("User token authentication successful - Valid User Token");
         SecurityContextHolder.getContext().setAuthentication(userTokenAuthentication.get());
       } else {
-        logger.info("User token authentication failed - Invalid User Token");
+        logger.debug("User token authentication failed - Invalid User Token");
         resolveUnauthorized(response);
         return;
       }

--- a/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZAuthenticationFilter.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZAuthenticationFilter.java
@@ -43,7 +43,9 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
 
         val authentication = serviceTokenAuthentication.get();
         SecurityContextHolder.getContext().setAuthentication(authentication);
+        logger.info("Service token authentication successful - Valid Service Token and Service ID");
       } else {
+        logger.info("Service token authentication failed - Invalid Service Token or Service ID");
         resolveUnauthorized(response);
         return;
       }
@@ -54,6 +56,7 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
       // request.
 
       if (!authorizationHeader.startsWith("Bearer ")) {
+        logger.info("User token authentication failed - No Bearer token");
         resolveUnauthorized(response);
         return;
       }
@@ -61,8 +64,10 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
       String bearerToken = authorizationHeader.substring(7);
       val userTokenAuthentication = getUserTokenAuthentication(bearerToken);
       if (userTokenAuthentication.isPresent()) {
+        logger.info("User token authentication successful - Valid User Token");
         SecurityContextHolder.getContext().setAuthentication(userTokenAuthentication.get());
       } else {
+        logger.info("User token authentication failed - Invalid User Token");
         resolveUnauthorized(response);
         return;
       }
@@ -75,7 +80,7 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
   }
 
   private void resolveUnauthorized(@NonNull HttpServletResponse response) throws IOException {
-    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
   }
 
   private Optional<AuthZUserTokenAuthentication> getUserTokenAuthentication(
@@ -113,5 +118,15 @@ public class AuthZAuthenticationFilter extends OncePerRequestFilter {
       logger.error("Provided service token failed verification request.", e);
       return Optional.empty();
     }
+  }
+
+  @Override
+  /**
+   * Overriding this method to return 'false' to allow this auth filter to handle authentication
+   * errors properly and return a 401 Unauthorized response instead of being bypassed to other
+   * filters which could result in a 403 Forbidden response.
+   */
+  protected boolean shouldNotFilterErrorDispatch() {
+    return false;
   }
 }

--- a/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZRestClient.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZRestClient.java
@@ -46,7 +46,7 @@ public class AuthZRestClient {
 
     val body = response.getBody();
 
-    log.info("Create Service Token. Response code: {} - body: {}", response.getStatusCode(), body);
+    log.debug("Create Service Token. Response code: {} - body: {}", response.getStatusCode(), body);
 
     if (body == null) {
       throw new RestClientException("Failed to retrieve Service Verification Token.");
@@ -83,7 +83,7 @@ public class AuthZRestClient {
 
     AuthZUserDetailsResponse userDetails = response.getBody();
 
-    log.info("Verify User Token. Response code: {} - body: {}", response.getStatusCode(), userDetails);
+    log.debug("Verify User Token. Response code: {} - body: {}", response.getStatusCode(), userDetails);
 
     if (userDetails == null) {
       return null;
@@ -146,7 +146,7 @@ public class AuthZRestClient {
 
     val body = response.getBody();
 
-    log.info("Verify Service Token. Response code: {} - body: {}", response.getStatusCode(), body);
+    log.debug("Verify Service Token. Response code: {} - body: {}", response.getStatusCode(), body);
 
     return body != null && body.isResult();
   }

--- a/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZRestClient.java
+++ b/song-server/src/main/java/bio/overture/song/server/security/authz/AuthZRestClient.java
@@ -6,6 +6,8 @@ import bio.overture.song.server.security.authz.dto.AuthZCreateServiceTokenRespon
 import bio.overture.song.server.security.authz.dto.AuthZServiceTokenVerificationResponse;
 import bio.overture.song.server.security.authz.dto.AuthZUserDetailsResponse;
 import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
@@ -15,6 +17,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+@Slf4j
 @Component
 public class AuthZRestClient {
   @Autowired private PCGLAuthZConfig pcglAuthZConfig;
@@ -42,6 +45,8 @@ public class AuthZRestClient {
         restTemplate.exchange(url, HttpMethod.POST, request, AuthZCreateServiceTokenResponse.class);
 
     val body = response.getBody();
+
+    log.info("Create Service Token. Response code: {} - body: {}", response.getStatusCode(), body);
 
     if (body == null) {
       throw new RestClientException("Failed to retrieve Service Verification Token.");
@@ -77,6 +82,9 @@ public class AuthZRestClient {
         restTemplate.exchange(url, HttpMethod.GET, request, AuthZUserDetailsResponse.class);
 
     AuthZUserDetailsResponse userDetails = response.getBody();
+
+    log.info("Verify User Token. Response code: {} - body: {}", response.getStatusCode(), userDetails);
+
     if (userDetails == null) {
       return null;
     }
@@ -137,6 +145,8 @@ public class AuthZRestClient {
             url, HttpMethod.GET, request, AuthZServiceTokenVerificationResponse.class);
 
     val body = response.getBody();
+
+    log.info("Verify Service Token. Response code: {} - body: {}", response.getStatusCode(), body);
 
     return body != null && body.isResult();
   }

--- a/song-server/src/main/resources/application.yml
+++ b/song-server/src/main/resources/application.yml
@@ -114,6 +114,7 @@ spring:
 logging:
   level:
     root: INFO
+    bio.overture.song: INFO
     io.swagger.models.parameters.AbstractSerializableParameter: ERROR
 
 ---


### PR DESCRIPTION
# Description
This PR updates the AuthZ Authentication Filter to properly handle authentication errors.

When authz token authentication fails, the filter now returns an HTTP `401 Unauthorized` response instead of `403 Forbidden`.

## Other changes:
- Added log statements in the Authz Rest Client class to include the status code and message to help troubleshooting.